### PR TITLE
Update runtime to GNOME 42

### DIFF
--- a/org.laptop.TurtleArtActivity.json
+++ b/org.laptop.TurtleArtActivity.json
@@ -1,7 +1,7 @@
 {
     "app-id": "org.laptop.TurtleArtActivity",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "3.34",
+    "runtime-version": "42",
     "sdk": "org.gnome.Sdk",
     "rename-desktop-file": "turtleblocks.desktop",
     "rename-icon": "turtleart",
@@ -26,6 +26,8 @@
     "cleanup": [
         "/include",
         "/lib/pkgconfig",
+        "/lib/python3.9/site-packages/numpy/tests",
+        "/lib/python3.9/site-packages/numpy/*/tests",
         "/share/aclocal",
         "/share/info",
         "/share/man"
@@ -44,57 +46,7 @@
             ]
         },
         "shared-modules/dbus-glib/dbus-glib-0.110.json",
-        {
-            "name": "python-dbus",
-            "buildsystem": "simple",
-            "build-commands": [
-                "pip3 install --no-index --find-links \"file://${PWD}\" --install-option=\"--prefix=${FLATPAK_DEST}\" dbus-python"
-            ],
-            "sources": [
-                {
-                    "type": "file",
-                    "url": "https://dbus.freedesktop.org/releases/dbus-python/dbus-python-1.2.12.tar.gz",
-                    "sha256": "cdd4de2c4f5e58f287b12013ed7b41dee81d503c8d0d2397c5bd2fb01badf260"
-                }
-            ]
-        },
-        {
-            "name": "decorator",
-            "buildsystem": "simple",
-            "build-commands": [
-                "pip3 install --no-index --find-links \"file://${PWD}\" --install-option=\"--prefix=${FLATPAK_DEST}\" decorator"
-            ],
-            "sources": [
-                {
-                    "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/ba/19/1119fe7b1e49b9c8a9f154c930060f37074ea2e8f9f6558efc2eeaa417a2/decorator-4.4.0.tar.gz",
-                    "sha256": "86156361c50488b84a3f148056ea716ca587df2f0de1d34750d35c21312725de"
-                }
-            ]
-        },
-        {
-            "name": "telepathy-python",
-            "no-parallel-make": true,
-            "rm-configure": true,
-            "sources": [
-                {
-                    "type": "archive",
-                    "url": "https://telepathy.freedesktop.org/releases/telepathy-python/telepathy-python-0.15.19.tar.gz",
-                    "sha256": "244c0e1bf4bbd78ae298ea659fe10bf3a73738db550156767cc2477aedf72376"
-                },
-                {
-                    "type": "patch",
-                    "path": "telepathy-python-fix-build.patch"
-                },
-                {
-                    "type": "script",
-                    "dest-filename": "autogen.sh",
-                    "commands": [
-                        "autoreconf -vif"
-                    ]
-                }
-            ]
-        },
+        "python3-requirements.json",
         {
             "name": "turtleblocks",
             "buildsystem": "simple",
@@ -105,7 +57,7 @@
                 {
                     "type": "git",
                     "url": "https://github.com/sugarlabs/turtleart-activity.git",
-                    "commit": "3625adde0840618bb5f5aec52fdf1d6ab1ae96c4"
+                    "commit": "1a9037ad613e3bfadeb9cd2dd3f423c767a2522c"
                 },
                 {
                     "type": "patch",
@@ -118,6 +70,10 @@
                 {
                     "type": "patch",
                     "path": "turtleblock-mime-icon-name.patch"
+                },
+                {
+                    "type": "patch",
+                    "path": "turtleblock-bump-version.patch"
                 }
             ],
             "post-install": [

--- a/python3-requirements.json
+++ b/python3-requirements.json
@@ -1,0 +1,49 @@
+{
+    "name": "python3-requirements",
+    "buildsystem": "simple",
+    "build-commands": [],
+    "modules": [
+        {
+            "name": "python3-dbus-python",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"dbus-python==1.2.18\" --no-build-isolation"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/b1/5c/ccfc167485806c1936f7d3ba97db6c448d0089c5746ba105b6eb22dba60e/dbus-python-1.2.18.tar.gz",
+                    "sha256": "92bdd1e68b45596c833307a5ff4b217ee6929a1502f5341bae28fd120acf7260"
+                }
+            ]
+        },
+        {
+            "name": "python3-decorator",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"decorator\" --no-build-isolation"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/d5/50/83c593b07763e1161326b3b8c6686f0f4b0f24d5526546bee538c89837d6/decorator-5.1.1-py3-none-any.whl",
+                    "sha256": "b8c3f85900b9dc423225913c5aace94729fe1fa9763b38939a95226f02d37186"
+                }
+            ]
+        },
+        {
+            "name": "python3-numpy",
+            "buildsystem": "simple",
+            "build-commands": [
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"numpy\" --no-build-isolation"
+            ],
+            "sources": [
+                {
+                    "type": "file",
+                    "url": "https://files.pythonhosted.org/packages/0a/88/f4f0c7a982efdf7bf22f283acf6009b29a9cc5835b684a49f8d3a4adb22f/numpy-1.23.3.tar.gz",
+                    "sha256": "51bf49c0cd1d52be0a240aa66f3458afc4b95d8993d2d04f0d91fa60c10af6cd"
+                }
+            ]
+        }
+    ]
+}

--- a/turtleblock-bump-version.patch
+++ b/turtleblock-bump-version.patch
@@ -1,0 +1,12 @@
+diff --git a/activity/activity.info b/activity/activity.info
+index 7b4a1b86..d4d2235c 100644
+--- a/activity/activity.info
++++ b/activity/activity.info
+@@ -1,6 +1,6 @@
+ [Activity]
+ name = TurtleBlocks
+-activity_version = 220
++activity_version = 220-54
+ license = MIT;GPLv2+;LGPLv2+;LGPLv2.1+;GPLv3+
+ metadata_license = CC0-1.0
+ bundle_id = org.laptop.TurtleArtActivity


### PR DESCRIPTION
* Update the runtime to GNOME 42

* Split the Python dependencies to python3-requirements.json which is generated by command [1]: "python3 flatpak-pip-generator --requirements-file=requirements.txt"

  Have the dependent Python libraries in the requirements.txt:
    dbus-python==1.2.18
    decorator
    numpy

* Bump turtleart-activity to commit 1a9037ad613e ("Fix the build error from the wrong option to setuptools") which upgrades to Python3, GTK3 and more fixes.

[1]: https://docs.flatpak.org/en/latest/python.html#building-multiple-python-dependencies