### PR TITLE
Update to GNOME 47 runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,22 @@
+Refreshing Python dependencies
+------------------------------
+
+Adjust build-only dependencies in `build-requirements.txt` as necessary, then
+run:
+
+```
+/path/to/flatpak-builder-tools/pip/flatpak-pip-generator \
+    --runtime $(jq -r '(.sdk + "//" + ."runtime-version")' org.laptop.TurtleArtActivity.json) \
+    -r build-requirements.txt \
+    --cleanup all \
+    --output python3-build-dependencies
+```
+
+Adjust runtime dependencies in `requirements.txt` as necessary, then run:
+
+```
+/path/to/flatpak-builder-tools/pip/flatpak-pip-generator \
+    --runtime $(jq -r '(.sdk + "//" + ."runtime-version")' org.laptop.TurtleArtActivity.json) \
+    -r requirements.txt \
+    --cleanup all
+```

--- a/build-requirements.txt
+++ b/build-requirements.txt
@@ -1,0 +1,1 @@
+meson-python

--- a/org.laptop.TurtleArtActivity.json
+++ b/org.laptop.TurtleArtActivity.json
@@ -1,7 +1,7 @@
 {
     "app-id": "org.laptop.TurtleArtActivity",
     "runtime": "org.gnome.Platform",
-    "runtime-version": "42",
+    "runtime-version": "47",
     "sdk": "org.gnome.Sdk",
     "rename-desktop-file": "turtleblocks.desktop",
     "rename-icon": "turtleart",
@@ -23,8 +23,8 @@
     "cleanup": [
         "/include",
         "/lib/pkgconfig",
-        "/lib/python3.9/site-packages/numpy/tests",
-        "/lib/python3.9/site-packages/numpy/*/tests",
+        "/lib/python*/site-packages/numpy/tests",
+        "/lib/python*/site-packages/numpy/*/tests",
         "/share/aclocal",
         "/share/info",
         "/share/man"
@@ -37,12 +37,25 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "http://download.sugarlabs.org/sources/sucrose/glucose/sugar-toolkit-gtk3/sugar-toolkit-gtk3-0.116.tar.xz",
-                    "sha256": "745a360577efceb10f57ca4cbad5f9ec61f7ed6cc381eeb72422bbd7455b770b"
+                    "url": "http://download.sugarlabs.org/sources/sucrose/glucose/sugar-toolkit-gtk3/sugar-toolkit-gtk3-0.121.tar.xz",
+                    "sha256": "2b508b28d75fe30967de0650dcc67aaacfa579e707b043a2e43785c315039c57"
                 }
             ]
         },
-        "shared-modules/dbus-glib/dbus-glib-0.110.json",
+        "shared-modules/dbus-glib/dbus-glib.json",
+        {
+            "//": "Runtime dependency of meson-python, which is a build dep of dbus-python",
+            "name": "patchelf",
+            "buildsystem": "autotools",
+            "cleanup": ["*"],
+            "sources": [{
+                "type": "git",
+                "url": "https://github.com/NixOS/patchelf.git",
+                "tag": "0.17.2",
+                "commit": "5908e16cd562bcb1909be4de0409c4912a8afc52"
+            }]
+        },
+        "python3-build-dependencies.json",
         "python3-requirements.json",
         {
             "name": "turtleblocks",
@@ -54,7 +67,7 @@
                 {
                     "type": "git",
                     "url": "https://github.com/sugarlabs/turtleart-activity.git",
-                    "commit": "1a9037ad613e3bfadeb9cd2dd3f423c767a2522c"
+                    "commit": "a4340adea18efbdb987eca6477fa71d5c924811f"
                 },
                 {
                     "type": "patch",

--- a/python3-build-dependencies.json
+++ b/python3-build-dependencies.json
@@ -1,0 +1,27 @@
+{
+    "name": "python3-meson-python",
+    "buildsystem": "simple",
+    "build-commands": [
+        "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"meson-python\" --no-build-isolation"
+    ],
+    "sources": [
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/7d/ec/40c0ddd29ef4daa6689a2b9c5ced47d5b58fa54ae149b19e9a97f4979c8c/meson_python-0.17.1-py3-none-any.whl",
+            "sha256": "30a75c52578ef14aff8392677b09c39346e0a24d2b2c6204b8ed30583c11269c"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/88/ef/eb23f262cca3c0c4eb7ab1933c3b1f03d021f2c48f54763065b6f0e321be/packaging-24.2-py3-none-any.whl",
+            "sha256": "09abb1bccd265c01f4a3aa3f7a7db064b36514d2cba19a2f694fe6150451a759"
+        },
+        {
+            "type": "file",
+            "url": "https://files.pythonhosted.org/packages/e8/61/9dd3e68d2b6aa40a5fc678662919be3c3a7bf22cba5a6b4437619b77e156/pyproject_metadata-0.9.0-py3-none-any.whl",
+            "sha256": "fc862aab066a2e87734333293b0af5845fe8ac6cb69c451a41551001e923be0b"
+        }
+    ],
+    "cleanup": [
+        "*"
+    ]
+}

--- a/python3-requirements.json
+++ b/python3-requirements.json
@@ -7,14 +7,18 @@
             "name": "python3-dbus-python",
             "buildsystem": "simple",
             "build-commands": [
-                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"dbus-python==1.2.18\" --no-build-isolation"
+                "pip3 install --verbose --exists-action=i --no-index --find-links=\"file://${PWD}\" --prefix=${FLATPAK_DEST} \"dbus-python\" --no-build-isolation"
             ],
             "sources": [
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/b1/5c/ccfc167485806c1936f7d3ba97db6c448d0089c5746ba105b6eb22dba60e/dbus-python-1.2.18.tar.gz",
-                    "sha256": "92bdd1e68b45596c833307a5ff4b217ee6929a1502f5341bae28fd120acf7260"
+                    "url": "https://files.pythonhosted.org/packages/c1/d3/6be85a9c772d6ebba0cc3ab37390dd6620006dcced758667e0217fb13307/dbus-python-1.3.2.tar.gz",
+                    "sha256": "ad67819308618b5069537be237f8e68ca1c7fcc95ee4a121fe6845b1418248f8"
                 }
+            ],
+            "cleanup": [
+                "/bin",
+                "/share/man/man1"
             ]
         },
         {
@@ -29,6 +33,10 @@
                     "url": "https://files.pythonhosted.org/packages/d5/50/83c593b07763e1161326b3b8c6686f0f4b0f24d5526546bee538c89837d6/decorator-5.1.1-py3-none-any.whl",
                     "sha256": "b8c3f85900b9dc423225913c5aace94729fe1fa9763b38939a95226f02d37186"
                 }
+            ],
+            "cleanup": [
+                "/bin",
+                "/share/man/man1"
             ]
         },
         {
@@ -40,9 +48,13 @@
             "sources": [
                 {
                     "type": "file",
-                    "url": "https://files.pythonhosted.org/packages/0a/88/f4f0c7a982efdf7bf22f283acf6009b29a9cc5835b684a49f8d3a4adb22f/numpy-1.23.3.tar.gz",
-                    "sha256": "51bf49c0cd1d52be0a240aa66f3458afc4b95d8993d2d04f0d91fa60c10af6cd"
+                    "url": "https://files.pythonhosted.org/packages/47/1b/1d565e0f6e156e1522ab564176b8b29d71e13d8caf003a08768df3d5cec5/numpy-2.2.0.tar.gz",
+                    "sha256": "140dd80ff8981a583a60980be1a655068f8adebf7a45a06a6858c873fcdcd4a0"
                 }
+            ],
+            "cleanup": [
+                "/bin",
+                "/share/man/man1"
             ]
         }
     ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+dbus-python
+decorator
+numpy


### PR DESCRIPTION
Add the necessary requirements.txt to regenerate
python3-requirements.json to the repo, along with a new build-requirements.txt to generate python3-build-dependencies.json.

Add instructions to a README on how to use these files to regenerate the Python module manifests.

Add a new non-Python build-dependency on patchelf.

Adjust the numpy test cleanup rule to be independent of the runtime's Python version.

Update shared-modules.

Supersedes #9.
Fixes #8.